### PR TITLE
add a reset method that reset the internal state of the signal handler

### DIFF
--- a/include/signal_handler/signal_handler.hpp
+++ b/include/signal_handler/signal_handler.hpp
@@ -38,6 +38,12 @@ public:
      */
     static bool has_received_sigint();
 
+    /**
+     * @brief Reset the status of the signal handler. No signals are considered
+     * caught.
+     */
+    static void reset();
+
 private:
     SignalHandler()
     {

--- a/src/signal_handler.cpp
+++ b/src/signal_handler.cpp
@@ -43,4 +43,10 @@ bool SignalHandler::has_received_sigint()
     return received_sigint_ != 0;
 }
 
+void SignalHandler::reset()
+{
+    SignalHandler::initialize();
+    received_sigint_ = 0;
+}
+
 }  // namespace signal_handler


### PR DESCRIPTION
Adds a reset method that reset the internal state of the signal handler.
So typically the SIGINT will be considered as "not seen".
This is for unit-testing purposes.
If you want to simulate a SIGINT for example, you need to reset the state between 2 tests otherwize the other tests will think that SIGINT as been flagged from the beggining.

I tested on implementing a unit-tests in the time_series package... This should be tested here as well I guess.
